### PR TITLE
fix/wrong submaterials id in budget and extras

### DIFF
--- a/src/components/common/FileUploader/FileUploader.tsx
+++ b/src/components/common/FileUploader/FileUploader.tsx
@@ -1,17 +1,13 @@
-import {
-  InputProps,
-  FormControl,
-  FormLabel,
-  InputGroup,
-  Input,
-} from '@chakra-ui/react';
+import { InputProps, InputGroup, Input } from '@chakra-ui/react';
 import { Pencil, Plus } from 'phosphor-react';
 import { useContext, useMemo, useState } from 'react';
+import FormControl, {
+  IFormControl,
+} from '../Form/Layout/FormControl/FormControl';
 import { useAppSelector } from '../../../redux/hooks';
 import { IFormElementProps } from '../../../types/forms';
 import Button from '../Button/Button';
 import { FormContext } from '../Form/Form';
-import { IFormControl } from '../Form/Layout/FormControl/FormControl';
 
 import styles from './FileUploader.module.css';
 
@@ -70,7 +66,6 @@ const FileUploader: React.FC<IFileUploader & InputProps> = props => {
       errorMessage={error || errors[name]}
       {...formControlProps}
     >
-      {label && <FormLabel>{label}</FormLabel>}
       <Button
         variant="ghost_outlined"
         className={`${styles.button} ${isUploaded ? styles.isUploaded : ''}`}

--- a/src/services/BudgetMaterialsService.ts
+++ b/src/services/BudgetMaterialsService.ts
@@ -147,7 +147,7 @@ export const createBudgetMaterial = async ({
         let subMatSubtotal = 0;
         subMaterials.forEach(e => {
           const { id, ...rest } = e;
-          batch.set(doc(collection(matRef, 'subMaterials')), rest);
+          batch.set(doc(matRef, 'subMaterials', id), rest);
           subMatSubtotal += rest.cost * rest.quantity;
         });
         summaryTotal += subMatSubtotal * rest.quantity;
@@ -166,6 +166,7 @@ export const createBudgetMaterial = async ({
       return {
         ...budgetMaterial,
         id: matRef.id,
+        subMaterials: rest.hasSubMaterials ? subMaterials : [],
       } as IBudgetMaterial;
     });
 

--- a/src/services/ExtraBudgetMaterialsService.ts
+++ b/src/services/ExtraBudgetMaterialsService.ts
@@ -152,7 +152,7 @@ export const createExtraBudgetMaterial = async ({
         let subMatSubtotal = 0;
         subMaterials.forEach(e => {
           const { id, ...rest } = e;
-          batch.set(doc(collection(matRef, 'subMaterials')), rest);
+          batch.set(doc(matRef, 'subMaterials', id), rest);
           subMatSubtotal += rest.cost * rest.quantity;
         });
         summaryTotal += subMatSubtotal * rest.quantity;
@@ -171,6 +171,7 @@ export const createExtraBudgetMaterial = async ({
       return {
         ...extraBudgetMaterial,
         id: matRef.id,
+        subMaterials: rest.hasSubMaterials ? subMaterials : [],
       } as IBudgetMaterial;
     });
 


### PR DESCRIPTION
Changes:
* When adding a material from the material management list, the sub-material ids are incorrect. This is now solved.
* The import inside the file uploader component was incorrect. Now is fixed.