### PR TITLE
Fix/modify budget hierarchy

### DIFF
--- a/src/components/reports/BudgetReport/BudgetReport.tsx
+++ b/src/components/reports/BudgetReport/BudgetReport.tsx
@@ -170,7 +170,7 @@ const BudgetReport: FC<Props> = props => {
 
         {activity.map((element, k) => (
           <Fragment key={k}>
-            <View className="mt-100" pdfMode={pdfMode}>
+            <View className="mt-30" pdfMode={pdfMode}>
               <Text className="fs-20 bold" pdfMode={pdfMode}>
                 {`Activity Details`}
               </Text>
@@ -205,11 +205,7 @@ const BudgetReport: FC<Props> = props => {
             </View>
             {!!element.materials?.length && (
               <>
-                <View className="mt-30" pdfMode={pdfMode}>
-                  <Text className="fs-20 left bold" pdfMode={pdfMode}>
-                    {`Materials`}
-                  </Text>
-
+                <View className="mt-10" pdfMode={pdfMode}>
                   <View className="bg-dark flex left" pdfMode={pdfMode}>
                     <View className="w-48 p-4-8" pdfMode={pdfMode}>
                       <Text className="white bold" pdfMode={pdfMode}>
@@ -379,395 +375,300 @@ const BudgetReport: FC<Props> = props => {
                 </View>
               </>
             )}
+          </Fragment>
+        ))}
 
-            {!!element.labors?.length && (
-              <>
-                <View className="mt-30" pdfMode={pdfMode}>
-                  <Text className="fs-20 left bold" pdfMode={pdfMode}>
-                    {`Labors`}
-                  </Text>
-                  <View className="bg-dark flex left" pdfMode={pdfMode}>
-                    <View className="w-48 p-4-8" pdfMode={pdfMode}>
-                      <Text className="white bold" pdfMode={pdfMode}>
-                        {`Description`}
-                      </Text>
-                    </View>
-                    <View className="w-10 p-4-8" pdfMode={pdfMode}>
-                      <Text className="white bold" pdfMode={pdfMode}>
-                        {`Qty.`}
-                      </Text>
-                    </View>
-                    <View className="w-10 p-4-8" pdfMode={pdfMode}>
-                      <Text className="white bold" pdfMode={pdfMode}>
-                        {`Unit`}
-                      </Text>
-                    </View>
-                    <View className="w-20 p-4-8" pdfMode={pdfMode}>
-                      <Text className="white bold" pdfMode={pdfMode}>
-                        {` Unit Cost`}
-                      </Text>
-                    </View>
-                    <View className="w-20 p-4-8" pdfMode={pdfMode}>
-                      <Text className="white bold" pdfMode={pdfMode}>
-                        {`Subtotal`}
-                      </Text>
-                    </View>
-                    <View className="w-15 p-4-8" pdfMode={pdfMode}>
-                      <Text className="white bold" pdfMode={pdfMode}>
-                        {`Dolars`}
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-                {element.labors.map((labor, i) => {
-                  return (
-                    <View key={i} className="row flex left" pdfMode={pdfMode}>
-                      <View className="w-48 p-4-8 pb-10" pdfMode={pdfMode}>
-                        <Text className="dark" pdfMode={pdfMode}>
-                          {labor.name}
-                        </Text>
-                      </View>
-                      <View className="w-10 p-4-8 pb-10" pdfMode={pdfMode}>
-                        <Text className="dark" pdfMode={pdfMode}>
-                          {`${labor.quantity}`}
-                        </Text>
-                      </View>
-                      <View className="w-10 p-4-8 pb-10" pdfMode={pdfMode}>
-                        <Text className="dark" pdfMode={pdfMode}>
-                          {labor.unit}
-                        </Text>
-                      </View>
-                      <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
-                        <Text className="dark" pdfMode={pdfMode}>
-                          {colonFormat(labor.cost)}
-                        </Text>
-                      </View>
-                      <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
-                        <Text className="dark" pdfMode={pdfMode}>
-                          {colonFormat(labor.quantity * labor.cost)}
-                        </Text>
-                      </View>
-                      <View className="w-15 p-4-8 pb-10" pdfMode={pdfMode}>
-                        <Text className="dark" pdfMode={pdfMode}>
-                          {dolarFormat(
-                            (labor.quantity * labor.cost) / budget.exchange,
-                          )}
-                        </Text>
-                      </View>
-                    </View>
-                  );
-                })}
-                <View className="flex left bg-gray p-5" pdfMode={pdfMode}>
-                  <View className="w-48 p-4-8 pb-10" pdfMode={pdfMode}>
-                    <Text className="bold" pdfMode={pdfMode}>
-                      {`TOTAL`}
-                    </Text>
-                  </View>
-                  <View className="w-10 p-4-8 pb-10" pdfMode={pdfMode}></View>
-                  <View className="w-10 p-4-8 pb-10" pdfMode={pdfMode}></View>
-                  <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
-                    <Text className="dark" pdfMode={pdfMode}>
-                      {colonFormat(calculateTotalCost(element.labors))}
-                    </Text>
-                  </View>
-                  <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
-                    <Text className="dark" pdfMode={pdfMode}>
-                      {colonFormat(element.sumLabors)}
-                    </Text>
-                  </View>
-                  <View className="w-15 p-4-8 pb-10" pdfMode={pdfMode}>
-                    <Text className="dark" pdfMode={pdfMode}>
-                      {dolarFormat(element.sumLabors / budget.exchange)}
-                    </Text>
-                  </View>
-                </View>
-              </>
-            )}
-
-            {!!element.subcontracts?.length && (
-              <>
-                <View className="mt-30" pdfMode={pdfMode}>
-                  <Text className="fs-20 left bold" pdfMode={pdfMode}>
-                    {`Subcontracts`}
-                  </Text>
-                  <View className="bg-dark flex left" pdfMode={pdfMode}>
-                    <View className="w-48 p-4-8" pdfMode={pdfMode}>
-                      <Text className="white bold" pdfMode={pdfMode}>
-                        {`Description`}
-                      </Text>
-                    </View>
-                    <View className="w-10 p-4-8" pdfMode={pdfMode}>
-                      <Text className="white bold" pdfMode={pdfMode}>
-                        {`Qty.`}
-                      </Text>
-                    </View>
-                    <View className="w-20 p-4-8" pdfMode={pdfMode}>
-                      <Text className="white bold" pdfMode={pdfMode}>
-                        {` Unit Cost`}
-                      </Text>
-                    </View>
-                    <View className="w-20 p-4-8" pdfMode={pdfMode}>
-                      <Text className="white bold" pdfMode={pdfMode}>
-                        {`Subtotal`}
-                      </Text>
-                    </View>
-                    <View className="w-15 p-4-8" pdfMode={pdfMode}>
-                      <Text className="white bold" pdfMode={pdfMode}>
-                        {`Dolars`}
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-                {element.subcontracts.map((labor, i) => {
-                  return (
-                    <View key={i} className="row flex left" pdfMode={pdfMode}>
-                      <View className="w-48 p-4-8 pb-10" pdfMode={pdfMode}>
-                        <Text className="dark" pdfMode={pdfMode}>
-                          {labor.name}
-                        </Text>
-                      </View>
-                      <View className="w-10 p-4-8 pb-10" pdfMode={pdfMode}>
-                        <Text className="dark" pdfMode={pdfMode}>
-                          {`${labor.quantity}`}
-                        </Text>
-                      </View>
-                      <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
-                        <Text className="dark" pdfMode={pdfMode}>
-                          {colonFormat(labor.cost)}
-                        </Text>
-                      </View>
-                      <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
-                        <Text className="dark" pdfMode={pdfMode}>
-                          {colonFormat(labor.quantity * labor.cost)}
-                        </Text>
-                      </View>
-                      <View className="w-15 p-4-8 pb-10" pdfMode={pdfMode}>
-                        <Text className="dark" pdfMode={pdfMode}>
-                          {dolarFormat(
-                            (labor.quantity * labor.cost) / budget.exchange,
-                          )}
-                        </Text>
-                      </View>
-                    </View>
-                  );
-                })}
-                <View className="flex left bg-gray p-5" pdfMode={pdfMode}>
-                  <View className="w-48 p-4-8 pb-10" pdfMode={pdfMode}>
-                    <Text className="bold" pdfMode={pdfMode}>
-                      {`TOTAL`}
-                    </Text>
-                  </View>
-                  <View className="w-10 p-4-8 pb-10" pdfMode={pdfMode}></View>
-                  <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
-                    <Text className="dark" pdfMode={pdfMode}>
-                      {colonFormat(calculateTotalCost(element.subcontracts))}
-                    </Text>
-                  </View>
-                  <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
-                    <Text className="dark" pdfMode={pdfMode}>
-                      {colonFormat(element.sumSubcontracts)}
-                    </Text>
-                  </View>
-                  <View className="w-15 p-4-8 pb-10" pdfMode={pdfMode}>
-                    <Text className="dark" pdfMode={pdfMode}>
-                      {dolarFormat(element.sumSubcontracts / budget.exchange)}
-                    </Text>
-                  </View>
-                </View>
-              </>
-            )}
-
-            {!!element.others?.length && (
-              <>
-                <View className="mt-30" pdfMode={pdfMode}>
-                  <Text className="fs-20 left bold" pdfMode={pdfMode}>
-                    {`Others Expenses`}
-                  </Text>
-                  <View className="bg-dark flex left" pdfMode={pdfMode}>
-                    <View className="w-48 p-4-8" pdfMode={pdfMode}>
-                      <Text className="white bold" pdfMode={pdfMode}>
-                        {`Description`}
-                      </Text>
-                    </View>
-                    <View className="w-10 p-4-8" pdfMode={pdfMode}>
-                      <Text className="white bold" pdfMode={pdfMode}>
-                        {`Qty.`}
-                      </Text>
-                    </View>
-                    <View className="w-20 p-4-8" pdfMode={pdfMode}>
-                      <Text className="white bold" pdfMode={pdfMode}>
-                        {` Unit Cost`}
-                      </Text>
-                    </View>
-                    <View className="w-20 p-4-8" pdfMode={pdfMode}>
-                      <Text className="white bold" pdfMode={pdfMode}>
-                        {`Subtotal`}
-                      </Text>
-                    </View>
-                    <View className="w-15 p-4-8" pdfMode={pdfMode}>
-                      <Text className="white bold" pdfMode={pdfMode}>
-                        {`Dolars`}
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-                {element.others.map((other, i) => {
-                  return (
-                    <View key={i} className="row flex left" pdfMode={pdfMode}>
-                      <View className="w-48 p-4-8 pb-10" pdfMode={pdfMode}>
-                        <Text className="dark" pdfMode={pdfMode}>
-                          {other.name}
-                        </Text>
-                      </View>
-                      <View className="w-10 p-4-8 pb-10" pdfMode={pdfMode}>
-                        <Text className="dark" pdfMode={pdfMode}>
-                          {`${other.quantity}`}
-                        </Text>
-                      </View>
-                      <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
-                        <Text className="dark" pdfMode={pdfMode}>
-                          {colonFormat(other.cost)}
-                        </Text>
-                      </View>
-                      <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
-                        <Text className="dark" pdfMode={pdfMode}>
-                          {colonFormat(other.quantity * other.cost)}
-                        </Text>
-                      </View>
-                      <View className="w-15 p-4-8 pb-10" pdfMode={pdfMode}>
-                        <Text className="dark" pdfMode={pdfMode}>
-                          {dolarFormat(
-                            (other.quantity * other.cost) / budget.exchange,
-                          )}
-                        </Text>
-                      </View>
-                    </View>
-                  );
-                })}
-                <View className="flex left bg-gray p-5" pdfMode={pdfMode}>
-                  <View className="w-48 p-4-8 pb-10" pdfMode={pdfMode}>
-                    <Text className="bold" pdfMode={pdfMode}>
-                      {`TOTAL`}
-                    </Text>
-                  </View>
-                  <View className="w-10 p-4-8 pb-10" pdfMode={pdfMode}></View>
-                  <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
-                    <Text className="dark" pdfMode={pdfMode}>
-                      {colonFormat(calculateTotalCost(element.others))}
-                    </Text>
-                  </View>
-                  <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
-                    <Text className="dark" pdfMode={pdfMode}>
-                      {colonFormat(element.sumOthers)}
-                    </Text>
-                  </View>
-                  <View className="w-15 p-4-8 pb-10" pdfMode={pdfMode}>
-                    <Text className="dark" pdfMode={pdfMode}>
-                      {dolarFormat(element.sumOthers / budget.exchange)}
-                    </Text>
-                  </View>
-                </View>
-              </>
-            )}
-
+        {!!budget.labors?.length && (
+          <>
             <View className="mt-30" pdfMode={pdfMode}>
               <Text className="fs-20 left bold" pdfMode={pdfMode}>
-                {`Summary`}
+                {`Labors`}
               </Text>
-              <View className="bg-dark flex center" pdfMode={pdfMode}>
-                <View className="w-50 p-4-8 " pdfMode={pdfMode}>
+              <View className="bg-dark flex left" pdfMode={pdfMode}>
+                <View className="w-48 p-4-8" pdfMode={pdfMode}>
                   <Text className="white bold" pdfMode={pdfMode}>
                     {`Description`}
                   </Text>
                 </View>
-                <View className="w-50 p-4-8" pdfMode={pdfMode}>
+                <View className="w-10 p-4-8" pdfMode={pdfMode}>
+                  <Text className="white bold" pdfMode={pdfMode}>
+                    {`Qty.`}
+                  </Text>
+                </View>
+                <View className="w-10 p-4-8" pdfMode={pdfMode}>
+                  <Text className="white bold" pdfMode={pdfMode}>
+                    {`Unit`}
+                  </Text>
+                </View>
+                <View className="w-20 p-4-8" pdfMode={pdfMode}>
+                  <Text className="white bold" pdfMode={pdfMode}>
+                    {` Unit Cost`}
+                  </Text>
+                </View>
+                <View className="w-20 p-4-8" pdfMode={pdfMode}>
+                  <Text className="white bold" pdfMode={pdfMode}>
+                    {`Subtotal`}
+                  </Text>
+                </View>
+                <View className="w-15 p-4-8" pdfMode={pdfMode}>
                   <Text className="white bold" pdfMode={pdfMode}>
                     {`Dolars`}
                   </Text>
                 </View>
               </View>
             </View>
-
-            {!!element.materials?.length && (
-              <View className="row flex center" pdfMode={pdfMode}>
-                <View className="w-50 p-4-8 pb-10" pdfMode={pdfMode}>
-                  <Text className="dark" pdfMode={pdfMode}>
-                    {`Materials`}
-                  </Text>
+            {budget.labors.map((labor, i) => {
+              return (
+                <View key={i} className="row flex left" pdfMode={pdfMode}>
+                  <View className="w-48 p-4-8 pb-10" pdfMode={pdfMode}>
+                    <Text className="dark" pdfMode={pdfMode}>
+                      {labor.name}
+                    </Text>
+                  </View>
+                  <View className="w-10 p-4-8 pb-10" pdfMode={pdfMode}>
+                    <Text className="dark" pdfMode={pdfMode}>
+                      {`${labor.quantity}`}
+                    </Text>
+                  </View>
+                  <View className="w-10 p-4-8 pb-10" pdfMode={pdfMode}>
+                    <Text className="dark" pdfMode={pdfMode}>
+                      {labor.unit}
+                    </Text>
+                  </View>
+                  <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
+                    <Text className="dark" pdfMode={pdfMode}>
+                      {colonFormat(labor.cost)}
+                    </Text>
+                  </View>
+                  <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
+                    <Text className="dark" pdfMode={pdfMode}>
+                      {colonFormat(labor.quantity * labor.cost)}
+                    </Text>
+                  </View>
+                  <View className="w-15 p-4-8 pb-10" pdfMode={pdfMode}>
+                    <Text className="dark" pdfMode={pdfMode}>
+                      {dolarFormat(
+                        (labor.quantity * labor.cost) / budget.exchange,
+                      )}
+                    </Text>
+                  </View>
                 </View>
-                <View className="w-50 p-4-8 pb-10" pdfMode={pdfMode}>
-                  <Text className="dark" pdfMode={pdfMode}>
-                    {dolarFormat(element.sumMaterials / budget.exchange)}
-                  </Text>
-                </View>
-              </View>
-            )}
-            {!!element.labors?.length && (
-              <View className="row flex center" pdfMode={pdfMode}>
-                <View className="w-50 p-4-8 pb-10" pdfMode={pdfMode}>
-                  <Text className="dark" pdfMode={pdfMode}>
-                    {`Labors`}
-                  </Text>
-                </View>
-                <View className="w-50 p-4-8 pb-10" pdfMode={pdfMode}>
-                  <Text className="dark" pdfMode={pdfMode}>
-                    {dolarFormat(element.sumLabors / budget.exchange)}
-                  </Text>
-                </View>
-              </View>
-            )}
-            {!!element.subcontracts?.length && (
-              <View className="row flex center" pdfMode={pdfMode}>
-                <View className="w-50 p-4-8 pb-10" pdfMode={pdfMode}>
-                  <Text className="dark" pdfMode={pdfMode}>
-                    {`Subcontracts`}
-                  </Text>
-                </View>
-                <View className="w-50 p-4-8 pb-10" pdfMode={pdfMode}>
-                  <Text className="dark" pdfMode={pdfMode}>
-                    {dolarFormat(element.sumSubcontracts / budget.exchange)}
-                  </Text>
-                </View>
-              </View>
-            )}
-            {!!element.others?.length && (
-              <View className="row flex center" pdfMode={pdfMode}>
-                <View className="w-50 p-4-8 pb-10" pdfMode={pdfMode}>
-                  <Text className="dark" pdfMode={pdfMode}>
-                    {`Others Expenses`}
-                  </Text>
-                </View>
-                <View className="w-50 p-4-8 pb-10" pdfMode={pdfMode}>
-                  <Text className="dark" pdfMode={pdfMode}>
-                    {dolarFormat(element.sumOthers / budget.exchange)}
-                  </Text>
-                </View>
-              </View>
-            )}
-
-            <View className="row flex center bg-gray p-5" pdfMode={pdfMode}>
-              <View className="w-50 p-4-8 pb-10" pdfMode={pdfMode}>
+              );
+            })}
+            <View className="flex left bg-gray p-5" pdfMode={pdfMode}>
+              <View className="w-48 p-4-8 pb-10" pdfMode={pdfMode}>
                 <Text className="bold" pdfMode={pdfMode}>
-                  {`Subtotal`}
+                  {`TOTAL`}
                 </Text>
               </View>
-
-              <View className="w-50 p-4-8 pb-10" pdfMode={pdfMode}>
+              <View className="w-10 p-4-8 pb-10" pdfMode={pdfMode}></View>
+              <View className="w-10 p-4-8 pb-10" pdfMode={pdfMode}></View>
+              <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
                 <Text className="dark" pdfMode={pdfMode}>
-                  {dolarFormat(
-                    (element.sumMaterials +
-                      element.sumLabors +
-                      element.sumSubcontracts +
-                      element.sumOthers) /
-                      budget.exchange,
-                  )}
+                  {colonFormat(calculateTotalCost(budget.labors))}
+                </Text>
+              </View>
+              <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
+                <Text className="dark" pdfMode={pdfMode}>
+                  {colonFormat(budget.sumLabors)}
+                </Text>
+              </View>
+              <View className="w-15 p-4-8 pb-10" pdfMode={pdfMode}>
+                <Text className="dark" pdfMode={pdfMode}>
+                  {dolarFormat(budget.sumLabors / budget.exchange)}
                 </Text>
               </View>
             </View>
-          </Fragment>
-        ))}
+          </>
+        )}
 
-        <View className="mt-100" pdfMode={pdfMode}>
+        {!!budget.subcontracts?.length && (
+          <>
+            <View className="mt-30" pdfMode={pdfMode}>
+              <Text className="fs-20 left bold" pdfMode={pdfMode}>
+                {`Subcontracts`}
+              </Text>
+              <View className="bg-dark flex left" pdfMode={pdfMode}>
+                <View className="w-48 p-4-8" pdfMode={pdfMode}>
+                  <Text className="white bold" pdfMode={pdfMode}>
+                    {`Description`}
+                  </Text>
+                </View>
+                <View className="w-10 p-4-8" pdfMode={pdfMode}>
+                  <Text className="white bold" pdfMode={pdfMode}>
+                    {`Qty.`}
+                  </Text>
+                </View>
+                <View className="w-20 p-4-8" pdfMode={pdfMode}>
+                  <Text className="white bold" pdfMode={pdfMode}>
+                    {` Unit Cost`}
+                  </Text>
+                </View>
+                <View className="w-20 p-4-8" pdfMode={pdfMode}>
+                  <Text className="white bold" pdfMode={pdfMode}>
+                    {`Subtotal`}
+                  </Text>
+                </View>
+                <View className="w-15 p-4-8" pdfMode={pdfMode}>
+                  <Text className="white bold" pdfMode={pdfMode}>
+                    {`Dolars`}
+                  </Text>
+                </View>
+              </View>
+            </View>
+            {budget.subcontracts.map((labor, i) => {
+              return (
+                <View key={i} className="row flex left" pdfMode={pdfMode}>
+                  <View className="w-48 p-4-8 pb-10" pdfMode={pdfMode}>
+                    <Text className="dark" pdfMode={pdfMode}>
+                      {labor.name}
+                    </Text>
+                  </View>
+                  <View className="w-10 p-4-8 pb-10" pdfMode={pdfMode}>
+                    <Text className="dark" pdfMode={pdfMode}>
+                      {`${labor.quantity}`}
+                    </Text>
+                  </View>
+                  <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
+                    <Text className="dark" pdfMode={pdfMode}>
+                      {colonFormat(labor.cost)}
+                    </Text>
+                  </View>
+                  <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
+                    <Text className="dark" pdfMode={pdfMode}>
+                      {colonFormat(labor.quantity * labor.cost)}
+                    </Text>
+                  </View>
+                  <View className="w-15 p-4-8 pb-10" pdfMode={pdfMode}>
+                    <Text className="dark" pdfMode={pdfMode}>
+                      {dolarFormat(
+                        (labor.quantity * labor.cost) / budget.exchange,
+                      )}
+                    </Text>
+                  </View>
+                </View>
+              );
+            })}
+            <View className="flex left bg-gray p-5" pdfMode={pdfMode}>
+              <View className="w-48 p-4-8 pb-10" pdfMode={pdfMode}>
+                <Text className="bold" pdfMode={pdfMode}>
+                  {`TOTAL`}
+                </Text>
+              </View>
+              <View className="w-10 p-4-8 pb-10" pdfMode={pdfMode}></View>
+              <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
+                <Text className="dark" pdfMode={pdfMode}>
+                  {colonFormat(calculateTotalCost(budget.subcontracts))}
+                </Text>
+              </View>
+              <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
+                <Text className="dark" pdfMode={pdfMode}>
+                  {colonFormat(budget.sumSubcontracts)}
+                </Text>
+              </View>
+              <View className="w-15 p-4-8 pb-10" pdfMode={pdfMode}>
+                <Text className="dark" pdfMode={pdfMode}>
+                  {dolarFormat(budget.sumSubcontracts / budget.exchange)}
+                </Text>
+              </View>
+            </View>
+          </>
+        )}
+
+        {!!budget.others?.length && (
+          <>
+            <View className="mt-30" pdfMode={pdfMode}>
+              <Text className="fs-20 left bold" pdfMode={pdfMode}>
+                {`Others Expenses`}
+              </Text>
+              <View className="bg-dark flex left" pdfMode={pdfMode}>
+                <View className="w-48 p-4-8" pdfMode={pdfMode}>
+                  <Text className="white bold" pdfMode={pdfMode}>
+                    {`Description`}
+                  </Text>
+                </View>
+                <View className="w-10 p-4-8" pdfMode={pdfMode}>
+                  <Text className="white bold" pdfMode={pdfMode}>
+                    {`Qty.`}
+                  </Text>
+                </View>
+                <View className="w-20 p-4-8" pdfMode={pdfMode}>
+                  <Text className="white bold" pdfMode={pdfMode}>
+                    {` Unit Cost`}
+                  </Text>
+                </View>
+                <View className="w-20 p-4-8" pdfMode={pdfMode}>
+                  <Text className="white bold" pdfMode={pdfMode}>
+                    {`Subtotal`}
+                  </Text>
+                </View>
+                <View className="w-15 p-4-8" pdfMode={pdfMode}>
+                  <Text className="white bold" pdfMode={pdfMode}>
+                    {`Dolars`}
+                  </Text>
+                </View>
+              </View>
+            </View>
+            {budget.others.map((other, i) => {
+              return (
+                <View key={i} className="row flex left" pdfMode={pdfMode}>
+                  <View className="w-48 p-4-8 pb-10" pdfMode={pdfMode}>
+                    <Text className="dark" pdfMode={pdfMode}>
+                      {other.name}
+                    </Text>
+                  </View>
+                  <View className="w-10 p-4-8 pb-10" pdfMode={pdfMode}>
+                    <Text className="dark" pdfMode={pdfMode}>
+                      {`${other.quantity}`}
+                    </Text>
+                  </View>
+                  <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
+                    <Text className="dark" pdfMode={pdfMode}>
+                      {colonFormat(other.cost)}
+                    </Text>
+                  </View>
+                  <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
+                    <Text className="dark" pdfMode={pdfMode}>
+                      {colonFormat(other.quantity * other.cost)}
+                    </Text>
+                  </View>
+                  <View className="w-15 p-4-8 pb-10" pdfMode={pdfMode}>
+                    <Text className="dark" pdfMode={pdfMode}>
+                      {dolarFormat(
+                        (other.quantity * other.cost) / budget.exchange,
+                      )}
+                    </Text>
+                  </View>
+                </View>
+              );
+            })}
+            <View className="flex left bg-gray p-5" pdfMode={pdfMode}>
+              <View className="w-48 p-4-8 pb-10" pdfMode={pdfMode}>
+                <Text className="bold" pdfMode={pdfMode}>
+                  {`TOTAL`}
+                </Text>
+              </View>
+              <View className="w-10 p-4-8 pb-10" pdfMode={pdfMode}></View>
+              <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
+                <Text className="dark" pdfMode={pdfMode}>
+                  {colonFormat(calculateTotalCost(budget.others))}
+                </Text>
+              </View>
+              <View className="w-20 p-4-8 pb-10" pdfMode={pdfMode}>
+                <Text className="dark" pdfMode={pdfMode}>
+                  {colonFormat(budget.sumOthers)}
+                </Text>
+              </View>
+              <View className="w-15 p-4-8 pb-10" pdfMode={pdfMode}>
+                <Text className="dark" pdfMode={pdfMode}>
+                  {dolarFormat(budget.sumOthers / budget.exchange)}
+                </Text>
+              </View>
+            </View>
+          </>
+        )}
+
+        <View className="mt-40" pdfMode={pdfMode}>
           <View className="row" pdfMode={pdfMode}>
             <Text className="fs-20 bold" pdfMode={pdfMode}>
               {`Grand Total`}

--- a/src/components/views/ProjectDetail/Budget/Budget.tsx
+++ b/src/components/views/ProjectDetail/Budget/Budget.tsx
@@ -11,7 +11,6 @@ import BudgetLabor from './BudgetLabor/BudgetLabor';
 import BudgetSubcontract from './BudgetSubcontract/BudgetSubcontract';
 import BudgetOther from './BudgetOther/BudgetOther';
 import BudgetSummary from './BudgetSummary/BudgetSummary';
-import ActivitySummary from './BudgetActivity/ActivitySummary/ActivitySummary';
 import Form from '../../../common/Form/Form';
 import ExchangeInput from '../../../common/ExchangeInput/ExchangeInput';
 import {
@@ -40,6 +39,7 @@ const Budget: React.FC<IBudgetView> = props => {
   const { projectId, project, setProject } = props;
   const [budget, setBudget] = useState<IProjectBudget>();
   const [activity, setActivity] = useState<IBudgetActivity>();
+  const [selectedActivityTab, setSelectedActivityTab] = useState(false);
   const [selectedTab, setSelectedTab] = useState('summary');
   const [editExchange, setEditExchange] = useState(false);
   const [editAdminFee, setEditAdminFee] = useState(false);
@@ -131,45 +131,8 @@ const Budget: React.FC<IBudgetView> = props => {
   const contentToDisplay = (option: string) => {
     const contentOptions: any = activity
       ? {
-          summary: (
-            <ActivitySummary
-              projectId={projectId}
-              budget={budget!}
-              activity={activity}
-            />
-          ),
           materials: (
             <BudgetMaterial
-              projectId={projectId}
-              isBudgetOpen={isBudgetOpen}
-              getBudget={getBudget}
-              budget={budget!}
-              getActivity={getActivity}
-              activity={activity}
-            />
-          ),
-          labors: (
-            <BudgetLabor
-              projectId={projectId}
-              isBudgetOpen={isBudgetOpen}
-              getBudget={getBudget}
-              budget={budget!}
-              getActivity={getActivity}
-              activity={activity}
-            />
-          ),
-          subcontracts: (
-            <BudgetSubcontract
-              projectId={projectId}
-              isBudgetOpen={isBudgetOpen}
-              getBudget={getBudget}
-              budget={budget!}
-              getActivity={getActivity}
-              activity={activity}
-            />
-          ),
-          others: (
-            <BudgetOther
               projectId={projectId}
               isBudgetOpen={isBudgetOpen}
               getBudget={getBudget}
@@ -190,6 +153,30 @@ const Budget: React.FC<IBudgetView> = props => {
               setActivity={setActivity}
             />
           ),
+          labors: (
+            <BudgetLabor
+              projectId={projectId}
+              isBudgetOpen={isBudgetOpen}
+              getBudget={getBudget}
+              budget={budget!}
+            />
+          ),
+          subcontracts: (
+            <BudgetSubcontract
+              projectId={projectId}
+              isBudgetOpen={isBudgetOpen}
+              getBudget={getBudget}
+              budget={budget!}
+            />
+          ),
+          others: (
+            <BudgetOther
+              projectId={projectId}
+              isBudgetOpen={isBudgetOpen}
+              getBudget={getBudget}
+              budget={budget!}
+            />
+          ),
         };
     return contentOptions[option];
   };
@@ -203,6 +190,7 @@ const Budget: React.FC<IBudgetView> = props => {
               <Button
                 onClick={() => {
                   setActivity(undefined);
+                  setSelectedActivityTab(true);
                 }}
                 variant={'ghost'}
               >
@@ -212,11 +200,11 @@ const Budget: React.FC<IBudgetView> = props => {
               <TabGroup
                 className={styles.tabs}
                 tabs={[
-                  { id: 'summary', name: appStrings.summary, selected: true },
-                  { id: 'materials', name: appStrings.materials },
-                  { id: 'labors', name: appStrings.labors },
-                  { id: 'subcontracts', name: appStrings.subcontracts },
-                  { id: 'others', name: appStrings.others },
+                  {
+                    id: 'materials',
+                    name: appStrings.materials,
+                    selected: true,
+                  },
                 ]}
                 variant="rounded"
                 onSelectedTabChange={activeTabs =>
@@ -228,8 +216,19 @@ const Budget: React.FC<IBudgetView> = props => {
             <TabGroup
               className={styles.tabs}
               tabs={[
-                { id: 'summary', name: appStrings.summary, selected: true },
-                { id: 'activity', name: appStrings.activities },
+                {
+                  id: 'summary',
+                  name: appStrings.summary,
+                  selected: !selectedActivityTab,
+                },
+                {
+                  id: 'activity',
+                  name: appStrings.activities,
+                  selected: selectedActivityTab,
+                },
+                { id: 'labors', name: appStrings.labors },
+                { id: 'subcontracts', name: appStrings.subcontracts },
+                { id: 'others', name: appStrings.others },
               ]}
               variant="rounded"
               onSelectedTabChange={activeTabs => setSelectedTab(activeTabs[0])}

--- a/src/components/views/ProjectDetail/Budget/BudgetActivity/BudgetActivity.tsx
+++ b/src/components/views/ProjectDetail/Budget/BudgetActivity/BudgetActivity.tsx
@@ -20,9 +20,9 @@ import Form, { DatePicker, Input } from '../../../../common/Form';
 import AlertDialog from '../../../../common/AlertDialog/AlertDialog';
 import { useAppSelector } from '../../../../../redux/hooks';
 import { colonFormat } from '../../../../../utils/numbers';
+import { formatDate } from '../../../../../utils/dates';
 
 import styles from './BudgetActivity.module.css';
-import { formatDate } from '../../../../../utils/dates';
 
 interface IBudgetActivityView {
   projectId: string;
@@ -56,13 +56,9 @@ const BudgetActivity: React.FC<IBudgetActivityView> = props => {
     { name: 'activity', value: appStrings.name },
     { name: 'date', value: appStrings.date },
     { name: 'sumMaterials', value: appStrings.materials, isGreen: true },
-    { name: 'sumLabors', value: appStrings.labors, isGreen: true },
-    {
-      name: 'sumSubcontracts',
-      value: appStrings.subcontracts,
-      isGreen: true,
-    },
-    { name: 'sumOthers', value: appStrings.others, isGreen: true },
+    { name: 'adminFee', value: appStrings.adminFee, isGreen: true },
+    { name: 'total', value: appStrings.total, isGreen: true },
+    { name: 'dollars', value: appStrings.dollars, isGreen: true },
   ];
 
   const formatTableData = () =>
@@ -70,9 +66,14 @@ const BudgetActivity: React.FC<IBudgetActivityView> = props => {
       ...data,
       date: formatDate(data.date, 'MM/DD/YYYY'),
       sumMaterials: colonFormat(data.sumMaterials),
-      sumLabors: colonFormat(data.sumLabors),
-      sumSubcontracts: colonFormat(data.sumSubcontracts),
-      sumOthers: colonFormat(data.sumOthers),
+      adminFee: colonFormat((data.sumMaterials * budget.adminFee) / 100),
+      total: colonFormat(
+        data.sumMaterials + (data.sumMaterials * budget.adminFee) / 100,
+      ),
+      dollars: colonFormat(
+        (data.sumMaterials + (data.sumMaterials * budget.adminFee) / 100) /
+          budget.exchange,
+      ),
     }));
 
   const getActivities = async () => {

--- a/src/components/views/ProjectDetail/Budget/BudgetActivity/BudgetActivity.tsx
+++ b/src/components/views/ProjectDetail/Budget/BudgetActivity/BudgetActivity.tsx
@@ -55,9 +55,7 @@ const BudgetActivity: React.FC<IBudgetActivityView> = props => {
   const tableHeader: TTableHeader[] = [
     { name: 'activity', value: appStrings.name },
     { name: 'date', value: appStrings.date },
-    { name: 'sumMaterials', value: appStrings.materials, isGreen: true },
-    { name: 'adminFee', value: appStrings.adminFee, isGreen: true },
-    { name: 'total', value: appStrings.total, isGreen: true },
+    { name: 'subtotal', value: appStrings.subtotal, isGreen: true },
     { name: 'dollars', value: appStrings.dollars, isGreen: true },
   ];
 
@@ -65,15 +63,8 @@ const BudgetActivity: React.FC<IBudgetActivityView> = props => {
     tableData.map(data => ({
       ...data,
       date: formatDate(data.date, 'MM/DD/YYYY'),
-      sumMaterials: colonFormat(data.sumMaterials),
-      adminFee: colonFormat((data.sumMaterials * budget.adminFee) / 100),
-      total: colonFormat(
-        data.sumMaterials + (data.sumMaterials * budget.adminFee) / 100,
-      ),
-      dollars: colonFormat(
-        (data.sumMaterials + (data.sumMaterials * budget.adminFee) / 100) /
-          budget.exchange,
-      ),
+      subtotal: colonFormat(data.sumMaterials),
+      dollars: colonFormat(data.sumMaterials / budget.exchange),
     }));
 
   const getActivities = async () => {

--- a/src/components/views/ProjectDetail/Budget/BudgetLabor/BudgetLabor.tsx
+++ b/src/components/views/ProjectDetail/Budget/BudgetLabor/BudgetLabor.tsx
@@ -16,7 +16,6 @@ import {
 } from '../../../../../services/BudgetLaborsService';
 import { IBudgetLabor } from '../../../../../types/budgetLabor';
 import { IProjectBudget } from '../../../../../types/projectBudget';
-import { IBudgetActivity } from '../../../../../types/budgetActivity';
 import Form, { Input } from '../../../../common/Form';
 import AlertDialog from '../../../../common/AlertDialog/AlertDialog';
 import { useAppSelector } from '../../../../../redux/hooks';
@@ -29,8 +28,6 @@ interface IBudgetLaborView {
   isBudgetOpen: boolean;
   getBudget: Function;
   budget: IProjectBudget;
-  getActivity: Function;
-  activity: IBudgetActivity;
 }
 
 const initialSelectedItemData = {
@@ -43,8 +40,7 @@ const initialSelectedItemData = {
 };
 
 const BudgetLabor: React.FC<IBudgetLaborView> = props => {
-  const { projectId, isBudgetOpen, getBudget, budget, getActivity, activity } =
-    props;
+  const { projectId, isBudgetOpen, getBudget, budget } = props;
   const [tableData, setTableData] = useState<IBudgetLabor[]>([]);
   const [selectedItem, setSelectedItem] = useState<IBudgetLabor>(
     initialSelectedItemData,
@@ -76,7 +72,6 @@ const BudgetLabor: React.FC<IBudgetLaborView> = props => {
       setTableData(response);
     await getBudgetLabors({
       projectId,
-      activityId: activity.id,
       appStrings,
       successCallback,
     });
@@ -105,7 +100,6 @@ const BudgetLabor: React.FC<IBudgetLaborView> = props => {
     };
     await getBudgetLaborById({
       projectId,
-      activityId: activity.id,
       budgetLaborId,
       appStrings,
       successCallback,
@@ -118,11 +112,9 @@ const BudgetLabor: React.FC<IBudgetLaborView> = props => {
       setSelectedItem(initialSelectedItemData);
       setIsAlertDialogOpen(false);
       getBudget();
-      getActivity(activity.id);
     };
     await deleteBudgetLabor({
       projectId,
-      activityId: activity.id,
       budgetLaborId: selectedItem.id,
       appStrings,
       successCallback,
@@ -139,11 +131,9 @@ const BudgetLabor: React.FC<IBudgetLaborView> = props => {
       setIsModalOpen(false);
       budgetLabor.id ? updateItem(item) : addItem(item);
       getBudget();
-      getActivity(activity.id);
     };
     const serviceCallParameters = {
       projectId,
-      activityId: activity.id,
       budgetLabor: {
         ...budgetLabor,
         quantity: +budgetLabor.quantity,

--- a/src/components/views/ProjectDetail/Budget/BudgetOther/BudgetOther.tsx
+++ b/src/components/views/ProjectDetail/Budget/BudgetOther/BudgetOther.tsx
@@ -16,7 +16,6 @@ import {
 } from '../../../../../services/BudgetOthersService';
 import { IBudgetOther } from '../../../../../types/budgetOther';
 import { IProjectBudget } from '../../../../../types/projectBudget';
-import { IBudgetActivity } from '../../../../../types/budgetActivity';
 import Form, { Input } from '../../../../common/Form';
 import AlertDialog from '../../../../common/AlertDialog/AlertDialog';
 import { useAppSelector } from '../../../../../redux/hooks';
@@ -29,8 +28,6 @@ interface IBudgetOtherView {
   isBudgetOpen: boolean;
   getBudget: Function;
   budget: IProjectBudget;
-  getActivity: Function;
-  activity: IBudgetActivity;
 }
 
 const initialSelectedItemData = {
@@ -42,8 +39,7 @@ const initialSelectedItemData = {
 };
 
 const BudgetOther: React.FC<IBudgetOtherView> = props => {
-  const { projectId, isBudgetOpen, getBudget, budget, getActivity, activity } =
-    props;
+  const { projectId, isBudgetOpen, getBudget, budget } = props;
   const [tableData, setTableData] = useState<IBudgetOther[]>([]);
   const [selectedItem, setSelectedItem] = useState<IBudgetOther>(
     initialSelectedItemData,
@@ -74,7 +70,6 @@ const BudgetOther: React.FC<IBudgetOtherView> = props => {
       setTableData(response);
     await getBudgetOthers({
       projectId,
-      activityId: activity.id,
       appStrings,
       successCallback,
     });
@@ -103,7 +98,7 @@ const BudgetOther: React.FC<IBudgetOtherView> = props => {
     };
     await getBudgetOtherById({
       projectId,
-      activityId: activity.id,
+
       budgetOtherId,
       appStrings,
       successCallback,
@@ -116,11 +111,10 @@ const BudgetOther: React.FC<IBudgetOtherView> = props => {
       setSelectedItem(initialSelectedItemData);
       setIsAlertDialogOpen(false);
       getBudget();
-      getActivity(activity.id);
     };
     await deleteBudgetOther({
       projectId,
-      activityId: activity.id,
+
       budgetOtherId: selectedItem.id,
       appStrings,
       successCallback,
@@ -137,11 +131,10 @@ const BudgetOther: React.FC<IBudgetOtherView> = props => {
       setIsModalOpen(false);
       budgetOther.id ? updateItem(item) : addItem(item);
       getBudget();
-      getActivity(activity.id);
     };
     const serviceCallParameters = {
       projectId,
-      activityId: activity.id,
+
       budgetOther: {
         ...budgetOther,
         quantity: +budgetOther.quantity,

--- a/src/components/views/ProjectDetail/Budget/BudgetOther/BudgetOther.tsx
+++ b/src/components/views/ProjectDetail/Budget/BudgetOther/BudgetOther.tsx
@@ -98,7 +98,6 @@ const BudgetOther: React.FC<IBudgetOtherView> = props => {
     };
     await getBudgetOtherById({
       projectId,
-
       budgetOtherId,
       appStrings,
       successCallback,
@@ -114,7 +113,6 @@ const BudgetOther: React.FC<IBudgetOtherView> = props => {
     };
     await deleteBudgetOther({
       projectId,
-
       budgetOtherId: selectedItem.id,
       appStrings,
       successCallback,
@@ -134,7 +132,6 @@ const BudgetOther: React.FC<IBudgetOtherView> = props => {
     };
     const serviceCallParameters = {
       projectId,
-
       budgetOther: {
         ...budgetOther,
         quantity: +budgetOther.quantity,

--- a/src/components/views/ProjectDetail/Budget/BudgetPreview/BudgetPreview.tsx
+++ b/src/components/views/ProjectDetail/Budget/BudgetPreview/BudgetPreview.tsx
@@ -40,7 +40,12 @@ export default function ActivityPreview() {
   };
 
   const getBudget = async () => {
-    const successCallback = (response: IProjectBudget) => setBudget(response);
+    const successCallback = async (response: IProjectBudget) => {
+      const labors = await getLabors();
+      const subcontracts = await getSubcontracts();
+      const others = await getOthers();
+      setBudget({ ...response, labors, subcontracts, others });
+    };
     await getProjectBudget({
       projectId,
       appStrings,
@@ -52,10 +57,7 @@ export default function ActivityPreview() {
     const successCallback = (response: IBudgetActivity[]) => {
       const list = response.map(async element => {
         const materials = await getMaterials(element.id);
-        const labors = await getLabors(element.id);
-        const subcontracts = await getSubcontracts(element.id);
-        const others = await getOthers(element.id);
-        return { ...element, materials, labors, subcontracts, others };
+        return { ...element, materials };
       });
       Promise.all(list).then(a => setActivity(a));
     };
@@ -81,37 +83,34 @@ export default function ActivityPreview() {
     return list;
   };
 
-  const getLabors = async (activityId: string) => {
+  const getLabors = async () => {
     let list: IBudgetLabor[] = [];
     const successCallback = (response: IBudgetLabor[]) => (list = response);
     await getBudgetLabors({
       projectId,
-      activityId,
       appStrings,
       successCallback,
     });
     return list;
   };
 
-  const getSubcontracts = async (activityId: string) => {
+  const getSubcontracts = async () => {
     let list: IBudgetSubcontract[] = [];
     const successCallback = (response: IBudgetSubcontract[]) =>
       (list = response);
     await getBudgetSubcontracts({
       projectId,
-      activityId,
       appStrings,
       successCallback,
     });
     return list;
   };
 
-  const getOthers = async (activityId: string) => {
+  const getOthers = async () => {
     let list: IBudgetOther[] = [];
     const successCallback = (response: IBudgetOther[]) => (list = response);
     await getBudgetOthers({
       projectId,
-      activityId,
       appStrings,
       successCallback,
     });

--- a/src/components/views/ProjectDetail/Budget/BudgetSubcontract/BudgetSubcontract.tsx
+++ b/src/components/views/ProjectDetail/Budget/BudgetSubcontract/BudgetSubcontract.tsx
@@ -16,7 +16,6 @@ import {
 } from '../../../../../services/BudgetSubcontractsService';
 import { IBudgetSubcontract } from '../../../../../types/budgetSubcontract';
 import { IProjectBudget } from '../../../../../types/projectBudget';
-import { IBudgetActivity } from '../../../../../types/budgetActivity';
 import Form, { Input } from '../../../../common/Form';
 import AlertDialog from '../../../../common/AlertDialog/AlertDialog';
 import { useAppSelector } from '../../../../../redux/hooks';
@@ -29,8 +28,6 @@ interface IBudgetSubcontractView {
   isBudgetOpen: boolean;
   getBudget: Function;
   budget: IProjectBudget;
-  getActivity: Function;
-  activity: IBudgetActivity;
 }
 
 const initialSelectedItemData = {
@@ -42,8 +39,7 @@ const initialSelectedItemData = {
 };
 
 const BudgetSubcontract: React.FC<IBudgetSubcontractView> = props => {
-  const { projectId, isBudgetOpen, getBudget, budget, getActivity, activity } =
-    props;
+  const { projectId, isBudgetOpen, getBudget, budget } = props;
   const [tableData, setTableData] = useState<IBudgetSubcontract[]>([]);
   const [selectedItem, setSelectedItem] = useState<IBudgetSubcontract>(
     initialSelectedItemData,
@@ -74,7 +70,6 @@ const BudgetSubcontract: React.FC<IBudgetSubcontractView> = props => {
       setTableData(response);
     await getBudgetSubcontracts({
       projectId,
-      activityId: activity.id,
       appStrings,
       successCallback,
     });
@@ -104,7 +99,6 @@ const BudgetSubcontract: React.FC<IBudgetSubcontractView> = props => {
     };
     await getBudgetSubcontractById({
       projectId,
-      activityId: activity.id,
       budgetSubcontractId,
       appStrings,
       successCallback,
@@ -117,11 +111,9 @@ const BudgetSubcontract: React.FC<IBudgetSubcontractView> = props => {
       setSelectedItem(initialSelectedItemData);
       setIsAlertDialogOpen(false);
       getBudget();
-      getActivity(activity.id);
     };
     await deleteBudgetSubcontract({
       projectId,
-      activityId: activity.id,
       budgetSubcontractId: selectedItem.id,
       appStrings,
       successCallback,
@@ -138,11 +130,9 @@ const BudgetSubcontract: React.FC<IBudgetSubcontractView> = props => {
       setIsModalOpen(false);
       budgetSubcontract.id ? updateItem(item) : addItem(item);
       getBudget();
-      getActivity(activity.id);
     };
     const serviceCallParameters = {
       projectId,
-      activityId: activity.id,
       budgetSubcontract: {
         ...budgetSubcontract,
         quantity: +budgetSubcontract.quantity,

--- a/src/services/BudgetActivityService.ts
+++ b/src/services/BudgetActivityService.ts
@@ -170,15 +170,11 @@ export const deleteBudgetActivity = async ({
     }
 
     await deleteCollect(`${actRef.path}/budgetMaterials`, ['subMaterials']);
-    await deleteCollect(`${actRef.path}/budgetLabors`);
-    await deleteCollect(`${actRef.path}/budgetSubcontracts`);
 
     const batch = writeBatch(db);
 
     batch.update(sumRef, {
       sumMaterials: increment(-actDoc.data().sumMaterials),
-      sumLabors: increment(-actDoc.data().sumLabors),
-      sumSubcontracts: increment(-actDoc.data().sumSubcontracts),
     });
     batch.delete(actRef);
 

--- a/src/services/BudgetSubcontractsService.ts
+++ b/src/services/BudgetSubcontractsService.ts
@@ -14,18 +14,17 @@ import { toastSuccess, toastError } from '../utils/toast';
 
 export const getBudgetSubcontracts = async ({
   projectId,
-  activityId,
   appStrings,
   successCallback,
   errorCallback,
-}: { projectId: string; activityId: string } & IService) => {
+}: { projectId: string } & IService) => {
   try {
     const subCtRef = collection(
       db,
       'projects',
       projectId,
       'projectBudget',
-      activityId,
+      'summary',
       'budgetSubcontracts',
     );
     const result = await getDocs(subCtRef);
@@ -48,14 +47,12 @@ export const getBudgetSubcontracts = async ({
 
 export const getBudgetSubcontractById = async ({
   projectId,
-  activityId,
   budgetSubcontractId,
   appStrings,
   successCallback,
   errorCallback,
 }: {
   projectId: string;
-  activityId: string;
   budgetSubcontractId: string;
 } & IService) => {
   try {
@@ -64,7 +61,7 @@ export const getBudgetSubcontractById = async ({
       'projects',
       projectId,
       'projectBudget',
-      activityId,
+      'summary',
       'budgetSubcontracts',
       budgetSubcontractId,
     );
@@ -88,14 +85,12 @@ export const getBudgetSubcontractById = async ({
 
 export const createBudgetSubcontract = async ({
   projectId,
-  activityId,
   budgetSubcontract,
   appStrings,
   successCallback,
   errorCallback,
 }: {
   projectId: string;
-  activityId: string;
   budgetSubcontract: IBudgetSubcontract;
 } & IService) => {
   try {
@@ -103,22 +98,18 @@ export const createBudgetSubcontract = async ({
       const { id, subtotal, ...rest } = budgetSubcontract;
       const budgetRef = collection(db, 'projects', projectId, 'projectBudget');
       const subCtRef = doc(
-        collection(budgetRef, activityId, 'budgetSubcontracts'),
+        collection(budgetRef, 'summary', 'budgetSubcontracts'),
       );
       const summaryRef = doc(budgetRef, 'summary');
-      const activityRef = doc(budgetRef, activityId);
       const summaryDoc = await transaction.get(summaryRef);
-      const activityDoc = await transaction.get(activityRef);
 
-      if (!summaryDoc.exists() || !activityDoc.exists()) {
+      if (!summaryDoc.exists()) {
         throw Error(appStrings.noRecords);
       }
 
       const summaryTotal = summaryDoc.data().sumSubcontracts + subtotal;
-      const activityTotal = activityDoc.data().sumSubcontracts + subtotal;
 
       transaction.update(summaryRef, { sumSubcontracts: summaryTotal });
-      transaction.update(activityRef, { sumSubcontracts: activityTotal });
       transaction.set(subCtRef, rest);
 
       return {
@@ -142,37 +133,31 @@ export const createBudgetSubcontract = async ({
 
 export const updateBudgetSubcontract = async ({
   projectId,
-  activityId,
   budgetSubcontract,
   appStrings,
   successCallback,
   errorCallback,
 }: {
   projectId: string;
-  activityId: string;
   budgetSubcontract: IBudgetSubcontract;
 } & IService) => {
   try {
     await runTransaction(db, async transaction => {
       const { id, subtotal, ...rest } = budgetSubcontract;
       const budgetRef = collection(db, 'projects', projectId, 'projectBudget');
-      const subCtRef = doc(budgetRef, activityId, 'budgetSubcontracts', id);
+      const subCtRef = doc(budgetRef, 'summary', 'budgetSubcontracts', id);
       const summaryRef = doc(budgetRef, 'summary');
-      const activityRef = doc(budgetRef, activityId);
       const subCtDoc = await transaction.get(subCtRef);
       const summaryDoc = await transaction.get(summaryRef);
-      const activityDoc = await transaction.get(activityRef);
 
-      if (!subCtDoc.exists() || !summaryDoc.exists() || !activityDoc.exists()) {
+      if (!subCtDoc.exists() || !summaryDoc.exists()) {
         throw Error(appStrings.noRecords);
       }
 
       const newSum = subtotal - subCtDoc.data().cost * subCtDoc.data().quantity;
       const summaryTotal = summaryDoc.data().sumSubcontracts + newSum;
-      const activityTotal = activityDoc.data().sumSubcontracts + newSum;
 
       transaction.update(summaryRef, { sumSubcontracts: summaryTotal });
-      transaction.update(activityRef, { sumSubcontracts: activityTotal });
       transaction.set(subCtRef, rest);
     });
 
@@ -191,41 +176,35 @@ export const updateBudgetSubcontract = async ({
 
 export const deleteBudgetSubcontract = async ({
   projectId,
-  activityId,
   budgetSubcontractId,
   appStrings,
   successCallback,
   errorCallback,
 }: {
   projectId: string;
-  activityId: string;
   budgetSubcontractId: string;
 } & IService) => {
   try {
     const budgetRef = collection(db, 'projects', projectId, 'projectBudget');
     const subCtRef = doc(
       budgetRef,
-      activityId,
+      'summary',
       'budgetSubcontracts',
       budgetSubcontractId,
     );
     const summaryRef = doc(budgetRef, 'summary');
-    const activityRef = doc(budgetRef, activityId);
     const subCtDoc = await getDoc(subCtRef);
     const summaryDoc = await getDoc(summaryRef);
-    const activityDoc = await getDoc(activityRef);
 
-    if (!subCtDoc.exists() || !summaryDoc.exists() || !activityDoc.exists()) {
+    if (!subCtDoc.exists() || !summaryDoc.exists()) {
       throw Error(appStrings.noRecords);
     }
 
     const batch = writeBatch(db);
     const newSum = subCtDoc.data().cost * subCtDoc.data().quantity;
     const summaryTotal = summaryDoc.data().sumSubcontracts - newSum;
-    const activityTotal = activityDoc.data().sumSubcontracts - newSum;
 
     batch.update(summaryRef, { sumSubcontracts: summaryTotal });
-    batch.update(activityRef, { sumSubcontracts: activityTotal });
     batch.delete(subCtRef);
 
     await batch.commit();

--- a/src/services/ExtraBudgetActivityService.ts
+++ b/src/services/ExtraBudgetActivityService.ts
@@ -249,6 +249,7 @@ export const deleteExtraBudgetActivity = async ({
     await deleteCollect(`${actRef.path}/budgetMaterials`, ['subMaterials']);
     await deleteCollect(`${actRef.path}/budgetLabors`);
     await deleteCollect(`${actRef.path}/budgetSubcontracts`);
+    await deleteCollect(`${actRef.path}/budgetOthers`);
 
     const batch = writeBatch(db);
 
@@ -256,6 +257,7 @@ export const deleteExtraBudgetActivity = async ({
       sumMaterials: increment(-actDoc.data().sumMaterials),
       sumLabors: increment(-actDoc.data().sumLabors),
       sumSubcontracts: increment(-actDoc.data().sumSubcontracts),
+      sumOthers: increment(-actDoc.data().sumOthers),
     });
     batch.delete(actRef);
 

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -223,12 +223,21 @@ export const deleteProject = async ({
     const extraBudgetRef = `${projectRef}/projectExtraBudget`;
 
     await deleteMaterialAndSubmaterials(budgetRef);
-    await deleteCollect(budgetRef, ['budgetLabors', 'budgetSubcontracts']);
+    await deleteCollect(budgetRef, [
+      'budgetLabors',
+      'budgetSubcontracts',
+      'budgetOthers',
+    ]);
     await deleteMaterialAndSubmaterials(extraBudgetRef);
-    await deleteCollect(extraBudgetRef, ['budgetLabors', 'budgetSubcontracts']);
+    await deleteCollect(extraBudgetRef, [
+      'budgetLabors',
+      'budgetSubcontracts',
+      'budgetOthers',
+    ]);
     await deleteCollect(`${projectRef}/projectBudget`);
     await deleteCollect(`${projectRef}/projectExtraBudget`);
-    await deleteCollect(`${projectRef}/projectInvoicing`);
+    await deleteCollect(`${projectRef}/projectOrders`, ['products']);
+    await deleteCollect(`${projectRef}/projectInvoicing`, ['products']);
     await deleteCollect(`${projectRef}/projectExpenses`);
     await deleteDoc(doc(db, projectRef));
 

--- a/src/types/budgetActivity.ts
+++ b/src/types/budgetActivity.ts
@@ -1,5 +1,3 @@
-import { IBudgetLabor } from './budgetLabor';
-import { IBudgetSubcontract } from './budgetSubcontract';
 import { IMaterialBreakdown } from './collections';
 
 export interface IBudgetActivity {
@@ -13,7 +11,4 @@ export interface IBudgetActivity {
   sumOthers: number;
   date: Date;
   materials?: IMaterialBreakdown[];
-  labors?: IBudgetLabor[];
-  subcontracts?: IBudgetSubcontract[];
-  others?: IBudgetSubcontract[];
 }

--- a/src/types/projectBudget.ts
+++ b/src/types/projectBudget.ts
@@ -1,3 +1,7 @@
+import { IBudgetLabor } from './budgetLabor';
+import { IBudgetOther } from './budgetOther';
+import { IBudgetSubcontract } from './budgetSubcontract';
+
 export interface IProjectBudget {
   sumLabors: number;
   sumMaterials: number;
@@ -6,4 +10,7 @@ export interface IProjectBudget {
   exchange: number;
   adminFee: number;
   creationDate: Date;
+  labors?: IBudgetLabor[];
+  subcontracts?: IBudgetSubcontract[];
+  others?: IBudgetOther[];
 }


### PR DESCRIPTION
One of the observations from the user was that the budget is composed by the activities, labors, subcontracts and other expenses in the same hierarchy level. So, the change was to level up the labors, subcontracts and other expenses to the activities level. This logic only applies in the budget and not in the extras section.
![image](https://user-images.githubusercontent.com/111327409/225972201-2d691e55-a876-4f7f-acc5-ce3363c45c42.png)
