### PR TITLE
Fix/ Calculation of materials subtotals need to be change

### DIFF
--- a/src/components/layout/MaterialsTableView/MaterialsTableView.tsx
+++ b/src/components/layout/MaterialsTableView/MaterialsTableView.tsx
@@ -86,10 +86,12 @@ const MaterialsTableView = <T extends TObject>(props: ITableProps<T>) => {
 
   const calculateDollars = (row: any) => {
     let total = 0;
-    const subMaterials = row.subMaterials;
-    if (row?.material.hasSubMaterials) {
-      subMaterials?.forEach((s: any) => {
-        total += Number(s.quantity) * Number.parseFloat(s.cost);
+    const subMaterials = row?.subMaterials;
+    if (row?.material?.hasSubMaterials) {
+      subMaterials?.forEach((element: any) => {
+        total +=
+          (Number(element?.quantity) * Number.parseFloat(element?.cost)) /
+          Number(row?.material?.quantity);
       });
       total *= Number(row?.material?.quantity);
     } else {
@@ -102,10 +104,12 @@ const MaterialsTableView = <T extends TObject>(props: ITableProps<T>) => {
 
   const calculateColons = (row: any) => {
     let total = 0;
-    const subMaterials = row.subMaterials;
-    if (row?.material.hasSubMaterials) {
-      subMaterials?.forEach((s: any) => {
-        total += Number(s.quantity) * Number.parseFloat(s.cost);
+    const subMaterials = row?.subMaterials;
+    if (row?.material?.hasSubMaterials) {
+      subMaterials?.forEach((element: any) => {
+        total +=
+          (Number(element?.quantity) * Number.parseFloat(element?.cost)) /
+          Number(row?.material?.quantity);
       });
     } else {
       total = Number(row?.material?.cost);

--- a/src/components/reports/BudgetReport/BudgetReport.tsx
+++ b/src/components/reports/BudgetReport/BudgetReport.tsx
@@ -61,10 +61,12 @@ const BudgetReport: FC<Props> = props => {
 
   const calculateMaterialCost = (row: any) => {
     let total = 0;
-    const subMaterials = row.subMaterials;
-    if (row?.material.hasSubMaterials) {
-      subMaterials?.forEach((s: any) => {
-        total += Number(s.quantity) * Number.parseFloat(s.cost);
+    const subMaterials = row?.subMaterials;
+    if (row?.material?.hasSubMaterials) {
+      subMaterials?.forEach((element: any) => {
+        total +=
+          (Number(element?.quantity) * Number.parseFloat(element?.cost)) /
+          Number(row?.material?.quantity);
       });
     } else {
       total = Number(row?.material?.cost);

--- a/src/components/reports/ExtraReport/ExtraReport.tsx
+++ b/src/components/reports/ExtraReport/ExtraReport.tsx
@@ -71,10 +71,12 @@ const ExtraReport: FC<Props> = props => {
 
   const calculateMaterialCost = (row: any) => {
     let total = 0;
-    const subMaterials = row.subMaterials;
-    if (row?.material.hasSubMaterials) {
-      subMaterials?.forEach((s: any) => {
-        total += Number(s.quantity) * Number.parseFloat(s.cost);
+    const subMaterials = row?.subMaterials;
+    if (row?.material?.hasSubMaterials) {
+      subMaterials?.forEach((element: any) => {
+        total +=
+          (Number(element?.quantity) * Number.parseFloat(element?.cost)) /
+          Number(row?.material?.quantity);
       });
     } else {
       total = Number(row?.material?.cost);

--- a/src/services/ExtraBudgetMaterialsService.ts
+++ b/src/services/ExtraBudgetMaterialsService.ts
@@ -319,8 +319,8 @@ export const createExtraBudgetMaterial = async ({
           });
           subMatSubtotal += rest.cost * rest.quantity;
         });
-        summaryTotal += subMatSubtotal * rest.quantity;
-        activityTotal += subMatSubtotal * rest.quantity;
+        summaryTotal += subMatSubtotal;
+        activityTotal += subMatSubtotal;
       } else {
         summaryTotal += subtotal;
         activityTotal += subtotal;
@@ -390,21 +390,20 @@ export const updateExtraBudgetMaterial = async ({
 
       let newSum = 0;
       let subMatSubtotal = 0;
+      //Material with submaterials
       if (matDoc.data()?.hasSubMaterials && rest.hasSubMaterials) {
         subMaterials?.forEach(m => (subMatSubtotal += m.cost * m.quantity));
-        newSum =
-          subMatSubtotal * rest.quantity -
-          subMatSubtotal * matDoc.data()?.quantity;
-      } else if (!matDoc.data()?.hasSubMaterials && rest.hasSubMaterials) {
+        newSum = subMatSubtotal - subMatSubtotal;
+      } //Changed material to have submaterials
+      else if (!matDoc.data()?.hasSubMaterials && rest.hasSubMaterials) {
         subMaterials?.forEach(m => (subMatSubtotal += m.cost * m.quantity));
-        newSum =
-          subMatSubtotal * rest.quantity -
-          matDoc.data()?.cost * matDoc.data()?.quantity;
-      } else if (matDoc.data()?.hasSubMaterials && !rest.hasSubMaterials) {
+        newSum = subMatSubtotal - matDoc.data()?.cost * matDoc.data()?.quantity;
+      } //Changed material to not have submaterials
+      else if (matDoc.data()?.hasSubMaterials && !rest.hasSubMaterials) {
         subMaterials?.forEach(m => (subMatSubtotal += m.cost * m.quantity));
-        newSum =
-          rest.cost * rest.quantity - subMatSubtotal * matDoc.data()?.quantity;
-      } else {
+        newSum = rest.cost * rest.quantity - subMatSubtotal;
+      } //Material without submaterials
+      else {
         newSum = subtotal - matDoc.data()?.cost * matDoc.data()?.quantity;
       }
 
@@ -471,7 +470,6 @@ export const deleteExtraBudgetMaterial = async ({
       for (const subMaterial of subMatDocs.docs) {
         newSum += subMaterial.data()?.cost * subMaterial.data()?.quantity;
       }
-      newSum *= matDoc.data()?.quantity;
     } else {
       newSum = matDoc.data()?.cost * matDoc.data()?.quantity;
     }
@@ -538,14 +536,13 @@ export const createExtraBudgetSubMaterial = async ({
     const data = await runTransaction(db, async transaction => {
       const summaryRef = doc(budgetRef, 'summary');
       const activityRef = doc(budgetRef, activityId);
-      const matDoc = await transaction.get(matRef);
       const summaryDoc = await transaction.get(summaryRef);
       const activityDoc = await transaction.get(activityRef);
 
-      if (!summaryDoc.exists() || !activityDoc.exists() || !matDoc.exists()) {
+      if (!summaryDoc.exists() || !activityDoc.exists()) {
         throw Error(appStrings.noRecords);
       }
-      const subtotal = rest.cost * rest.quantity * matDoc.data()?.quantity;
+      const subtotal = rest.cost * rest.quantity;
       const summaryTotal = summaryDoc.data()?.sumMaterials + subtotal;
       const activityTotal = activityDoc.data()?.sumMaterials + subtotal;
 
@@ -593,7 +590,7 @@ export const updateExtraBudgetSubMaterial = async ({
   budgetSubMaterial: ISubMaterial;
 } & IService) => {
   try {
-    const { id, ...rest } = budgetSubMaterial;
+    const { id, createdAt, ...rest } = budgetSubMaterial;
     const budgetRef = collection(
       db,
       'projects',
@@ -612,13 +609,11 @@ export const updateExtraBudgetSubMaterial = async ({
     await runTransaction(db, async transaction => {
       const summaryRef = doc(budgetRef, 'summary');
       const activityRef = doc(budgetRef, activityId);
-      const matDoc = await transaction.get(matRef);
       const subMatDoc = await transaction.get(subMatRef);
       const summaryDoc = await transaction.get(summaryRef);
       const activityDoc = await transaction.get(activityRef);
 
       if (
-        !matDoc.exists() ||
         !subMatDoc.exists() ||
         !summaryDoc.exists() ||
         !activityDoc.exists()
@@ -626,11 +621,8 @@ export const updateExtraBudgetSubMaterial = async ({
         throw Error(appStrings.noRecords);
       }
 
-      const subtotal = rest.cost * rest.quantity * matDoc.data()?.quantity;
-      const oldSubtotal =
-        subMatDoc.data()?.cost *
-        subMatDoc.data()?.quantity *
-        matDoc.data()?.quantity;
+      const subtotal = rest.cost * rest.quantity;
+      const oldSubtotal = subMatDoc.data()?.cost * subMatDoc.data()?.quantity;
       const newSum = subtotal - oldSubtotal;
       const summaryTotal = summaryDoc.data()?.sumMaterials + newSum;
       const activityTotal = activityDoc.data()?.sumMaterials + newSum;
@@ -638,7 +630,7 @@ export const updateExtraBudgetSubMaterial = async ({
       transaction.update(summaryRef, { sumMaterials: summaryTotal });
       transaction.update(activityRef, { sumMaterials: activityTotal });
       transaction.update(matRef, { updatedAt: serverTimestamp() });
-      transaction.set(subMatRef, { ...rest, updatedAt: serverTimestamp() });
+      transaction.update(subMatRef, { ...rest, updatedAt: serverTimestamp() });
     });
     await updateDoc(matRef, { updatedAt: serverTimestamp() });
 
@@ -680,26 +672,17 @@ export const deleteExtraBudgetSubMaterial = async ({
     const subMatRef = doc(matRef, 'subMaterials', extraBudgetSubMaterialId);
     const summaryRef = doc(budgetRef, 'summary');
     const activityRef = doc(budgetRef, activityId);
-    const matDoc = await getDoc(matRef);
     const subMatDoc = await getDoc(subMatRef);
     const summaryDoc = await getDoc(summaryRef);
     const activityDoc = await getDoc(activityRef);
 
-    if (
-      !matDoc.exists() ||
-      !subMatDoc.exists() ||
-      !summaryDoc.exists() ||
-      !activityDoc.exists()
-    ) {
+    if (!subMatDoc.exists() || !summaryDoc.exists() || !activityDoc.exists()) {
       throw Error(appStrings.noRecords);
     }
 
     const batch = writeBatch(db);
 
-    const newSum =
-      subMatDoc.data()?.cost *
-      subMatDoc.data()?.quantity *
-      matDoc.data()?.quantity;
+    const newSum = subMatDoc.data()?.cost * subMatDoc.data()?.quantity;
     const summaryTotal = summaryDoc.data()?.sumMaterials - newSum;
     const activityTotal = activityDoc.data()?.sumMaterials - newSum;
 


### PR DESCRIPTION
Previously the subtotal for materials with submaterial was calculated by multiplying the cost and quantity of the material. 
But the logic is different, because the summatory of the subtotals of all submaterials y the subtotal of the father material.
Example:
![image](https://github.com/hermosasoftware/construction-budget-manager/assets/111327409/7809ecc5-3813-4e88-81bc-1c8748af5c2d)
